### PR TITLE
Fix for `TypeError: quickSettings._brightness is undefined`

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -133,15 +133,15 @@ class Indicator extends SystemIndicator {
         luminosità e lo segnala come undefined.
         */
         
-        const brightnessItem = quickSettings._brightness.quickSettingsItems[0];
+        const brightnessItem = quickSettings._brightness?.quickSettingsItems?.[0];
         const items = quickSettings.menu._grid.get_children();
-        const brightnessIndex = items.indexOf(brightnessItem);
+        const brightnessIndex = brightnessItem ? items.indexOf(brightnessItem) : -1;
         const nextItem = brightnessIndex >= 0 ? items[brightnessIndex + 1] : null;
 
         if (brightnessItem && nextItem) {
             extLog(`Indicator added after the Brightness Slider.`)
             quickSettings.menu.insertItemBefore(
-                item, 
+                item,
                 nextItem,
                 colSpan
             )


### PR DESCRIPTION
Hi, thanks for a great extension!

I was experiencing an error as my system doesn't have a display brightness slider, since I'm using an external monitor. If the display brightness slider doesn't exist, the extension doesn't load at all.

I saw this error in `journalctl`:

```
Jul 07 20:55:11 joejoinerr gnome-shell[1111547]: Extension night-light-slider@devoscarm.github.com: TypeError: quickSettings._brightness is undefined
                                                      _init@file:///home/joejoinerr/.local/share/gnome-shell/extensions/night-light-slider@devoscarm.github.com/extension.js:136:32
                                                      Indicator@file:///home/joejoinerr/.local/share/gnome-shell/extensions/night-light-slider@devoscarm.github.com/extension.js:121:1
                                                      enable@file:///home/joejoinerr/.local/share/gnome-shell/extensions/night-light-slider@devoscarm.github.com/extension.js:173:31
```

This PR is just a small change so that the extension can still load and be placed at the bottom of quick settings.